### PR TITLE
remove pane on open

### DIFF
--- a/plugin/blog.vim
+++ b/plugin/blog.vim
@@ -689,7 +689,7 @@ def blog_wise_open_view():
         vim.command(":new")
     vim.command('setl syntax=blogsyntax')
     vim.command('setl completefunc=Completable')
-
+    vim.command(":only")
 
 @vim_encoding_check
 def vim_input(message = 'input', secret = False):


### PR DESCRIPTION
I found that by default VimBlog create a couple splits unnecessarily afaik.  This helps to focus on the blog we wish to edit.  Thoughts?
